### PR TITLE
docs: 개인정보처리방침 정적 페이지 추가

### DIFF
--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>플랜메이트(PlanMate) 개인정보처리방침</title>
+<meta name="description" content="플랜메이트(PlanMate) 개인정보처리방침" />
+<meta name="robots" content="index, follow" />
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 40px 20px 80px;
+    font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
+                 "Pretendard", "Noto Sans KR", "Malgun Gothic", sans-serif;
+    line-height: 1.75;
+    color: #1f2328;
+    background: #fff;
+  }
+  .wrap { max-width: 780px; margin: 0 auto; }
+  h1 { font-size: 1.9rem; margin: 0 0 8px; letter-spacing: -0.02em; }
+  h2 {
+    font-size: 1.2rem; margin: 44px 0 12px; padding-top: 20px;
+    border-top: 1px solid #e5e7eb; letter-spacing: -0.01em;
+  }
+  h3 { font-size: 1rem; margin: 24px 0 8px; }
+  p, li { font-size: 0.97rem; }
+  ul, ol { padding-left: 22px; }
+  li { margin: 6px 0; }
+  .meta { color: #6b7280; font-size: 0.9rem; margin-bottom: 32px; }
+  .lead {
+    background: #f6f8fa; border: 1px solid #e5e7eb; border-radius: 10px;
+    padding: 16px 20px; font-size: 0.95rem;
+  }
+  table {
+    width: 100%; border-collapse: collapse; margin: 14px 0; font-size: 0.9rem;
+    display: block; overflow-x: auto; white-space: nowrap;
+  }
+  th, td { border: 1px solid #e5e7eb; padding: 10px 12px; text-align: left; vertical-align: top; }
+  th { background: #f6f8fa; font-weight: 600; }
+  a { color: #2563eb; }
+  footer {
+    margin-top: 56px; padding-top: 20px; border-top: 1px solid #e5e7eb;
+    color: #6b7280; font-size: 0.88rem;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { background: #0d1117; color: #e6edf3; }
+    h2 { border-color: #30363d; }
+    .lead { background: #161b22; border-color: #30363d; }
+    th, td { border-color: #30363d; }
+    th { background: #161b22; }
+    .meta, footer { color: #9198a1; }
+    footer { border-color: #30363d; }
+    a { color: #6ea8fe; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>개인정보처리방침</h1>
+<p class="meta">플랜메이트(PlanMate) · 시행일: 2026년 7월 18일</p>
+
+<p class="lead">
+플랜메이트(이하 “서비스”)는 이용자의 개인정보를 중요하게 생각하며,
+「개인정보 보호법」 등 관련 법령을 준수합니다.
+본 방침은 서비스가 어떤 개인정보를 어떤 목적으로 수집·이용하며,
+어떻게 보관하고 파기하는지를 안내합니다.
+</p>
+
+<h2>1. 수집하는 개인정보 항목 및 수집 방법</h2>
+
+<h3>가. 회원가입 및 로그인</h3>
+<table>
+  <thead>
+    <tr><th>구분</th><th>수집 항목</th><th>필수 여부</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>이메일 회원가입</td><td>이메일 주소, 비밀번호(암호화 저장), 닉네임</td><td>필수</td></tr>
+    <tr><td>소셜 로그인<br>(구글 · 네이버 · 카카오)</td><td>소셜 계정 식별자, 이메일 주소, 프로필 닉네임</td><td>필수</td></tr>
+    <tr><td>프로필 정보</td><td>생년월일, 성별</td><td>선택</td></tr>
+  </tbody>
+</table>
+
+<h3>나. 서비스 이용 과정에서 생성·수집되는 정보</h3>
+<ul>
+  <li>이용자가 직접 입력한 여행 일정 정보: 여행지, 목적지, 일정 제목·날짜, 시간표 및 장소 블록</li>
+  <li>여행 취향 및 테마 선택 정보</li>
+  <li>동행자 초대·수락 등 협업 관련 정보</li>
+  <li>푸시 알림 발송을 위한 기기 토큰(FCM 토큰)</li>
+  <li>베타 피드백 등 이용자가 자발적으로 제출한 의견</li>
+  <li>서비스 이용 기록, 접속 로그, 접속 IP 주소(보안 및 장애 대응 목적으로 자동 생성)</li>
+</ul>
+
+<h3>다. 수집 방법</h3>
+<ul>
+  <li>회원가입 및 서비스 이용 과정에서 이용자가 직접 입력</li>
+  <li>소셜 로그인 제공자로부터 이용자의 동의를 거쳐 전달받음</li>
+  <li>서비스 이용 과정에서 자동으로 생성되어 수집</li>
+</ul>
+
+<h2>2. 개인정보의 수집·이용 목적</h2>
+<ul>
+  <li><strong>회원 관리</strong> — 회원 식별, 본인 확인, 로그인 유지, 부정 이용 방지, 문의 응대</li>
+  <li><strong>서비스 제공</strong> — 여행 일정 생성·저장·조회, 일정 추천, 경로 및 대중교통 정보 안내</li>
+  <li><strong>동행 기능 제공</strong> — 일정 공유, 동행 요청 및 수락, 공동 편집</li>
+  <li><strong>알림 발송</strong> — 동행 요청, 일정 변경 등 서비스 관련 푸시 알림 및 안내</li>
+  <li><strong>서비스 개선</strong> — 이용 통계 분석, 오류 및 장애 대응, 신규 기능 개발</li>
+</ul>
+
+<h2>3. 개인정보의 보유 및 이용 기간</h2>
+<p>
+서비스는 원칙적으로 개인정보 수집·이용 목적이 달성되면 해당 정보를 지체 없이 파기합니다.
+다만 다음의 경우에는 명시한 기간 동안 보관합니다.
+</p>
+<table>
+  <thead>
+    <tr><th>보관 항목</th><th>보관 기간</th><th>근거</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>회원 정보</td><td>회원 탈퇴 시까지</td><td>서비스 제공</td></tr>
+    <tr><td>탈퇴 회원 정보</td><td>탈퇴 후 30일 이내 파기</td><td>부정 재가입 및 오류 복구 대응</td></tr>
+    <tr><td>서비스 이용 기록, 접속 로그, 접속 IP</td><td>3개월</td><td>통신비밀보호법</td></tr>
+  </tbody>
+</table>
+<p>
+관계 법령에 따라 보존이 필요한 경우에는 해당 법령에서 정한 기간 동안 보관한 후 파기합니다.
+</p>
+
+<h2>4. 개인정보의 파기 절차 및 방법</h2>
+<ul>
+  <li><strong>파기 절차</strong> — 보유 기간이 경과하거나 처리 목적이 달성된 개인정보는 내부 방침 및 관련 법령에 따라 지체 없이 파기합니다.</li>
+  <li><strong>파기 방법</strong> — 전자적 파일 형태의 정보는 복구할 수 없는 기술적 방법으로 삭제하며, 출력물은 분쇄하거나 소각합니다.</li>
+</ul>
+
+<h2>5. 개인정보의 제3자 제공</h2>
+<p>
+서비스는 이용자의 개인정보를 제3자에게 제공하지 않습니다.
+다만 다음의 경우에는 예외로 합니다.
+</p>
+<ul>
+  <li>이용자가 사전에 명시적으로 동의한 경우</li>
+  <li>법령에 근거하거나, 수사기관이 적법한 절차에 따라 요구한 경우</li>
+</ul>
+<p>
+동행 기능을 이용하는 경우, 이용자가 직접 초대·수락한 동행자에게 닉네임과 해당 일정 정보가 공유됩니다.
+이는 이용자의 선택에 따른 서비스 기능이며, 동행 관계 해제 시 공유도 종료됩니다.
+</p>
+
+<h2>6. 개인정보 처리의 위탁</h2>
+<p>서비스는 원활한 서비스 제공을 위해 다음과 같이 업무를 위탁하고 있습니다.</p>
+<table>
+  <thead>
+    <tr><th>수탁자</th><th>위탁 업무</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Google (Firebase Cloud Messaging)</td><td>푸시 알림 발송</td></tr>
+    <tr><td>Google (Gemini API)</td><td>여행 일정 추천 기능 처리</td></tr>
+    <tr><td>ODsay</td><td>대중교통 경로 조회</td></tr>
+    <tr><td>OpenStreetMap</td><td>도보 경로 조회</td></tr>
+  </tbody>
+</table>
+<p>
+경로 조회 및 일정 추천 기능에는 이용자가 입력한 여행지·목적지 정보가 전달되며,
+이름·이메일 등 이용자를 직접 식별할 수 있는 정보는 전달되지 않습니다.
+</p>
+
+<h2>7. 개인정보의 국외 이전</h2>
+<p>
+위 제6조의 수탁 업무 처리 과정에서 일부 정보가 국외 서버로 이전될 수 있습니다.
+이전되는 항목과 목적은 제6조에 기재된 범위에 한하며, 이전 국가는 각 수탁자의 서버 소재지입니다.
+이용자는 국외 이전을 거부할 수 있으며, 이 경우 해당 기능의 이용이 제한될 수 있습니다.
+</p>
+
+<h2>8. 이용자의 권리와 행사 방법</h2>
+<p>이용자는 언제든지 다음의 권리를 행사할 수 있습니다.</p>
+<ul>
+  <li>개인정보 열람 요구</li>
+  <li>오류가 있는 경우 정정 요구</li>
+  <li>삭제 요구</li>
+  <li>처리 정지 요구</li>
+</ul>
+<p>
+위 권리는 서비스 내 <strong>마이페이지</strong>에서 직접 행사하거나,
+아래 연락처로 서면·이메일을 통해 요청할 수 있습니다.
+서비스는 요청을 받은 즉시 필요한 조치를 취합니다.
+</p>
+<p>
+회원 탈퇴는 서비스 내 <strong>마이페이지 &gt; 탈퇴하기</strong>에서 직접 진행할 수 있으며,
+탈퇴 시 개인정보는 제3조에 명시된 기간 내에 파기됩니다.
+</p>
+
+<h2>9. 만 14세 미만 아동의 개인정보</h2>
+<p>
+서비스는 만 14세 미만 아동의 개인정보를 수집하지 않습니다.
+만 14세 미만 아동의 개인정보가 수집된 사실이 확인될 경우 지체 없이 해당 정보를 파기합니다.
+</p>
+
+<h2>10. 개인정보의 안전성 확보 조치</h2>
+<ul>
+  <li><strong>비밀번호 암호화</strong> — 비밀번호는 복호화가 불가능한 일방향 암호화 방식으로 저장합니다.</li>
+  <li><strong>전송 구간 암호화</strong> — 모든 통신은 HTTPS(TLS)로 암호화하여 전송합니다.</li>
+  <li><strong>접근 권한 관리</strong> — 개인정보에 접근할 수 있는 인원을 최소한으로 제한하고 권한을 관리합니다.</li>
+  <li><strong>접속 기록 보관</strong> — 개인정보처리시스템의 접속 기록을 보관·점검합니다.</li>
+</ul>
+
+<h2>11. 개인정보 보호책임자</h2>
+<p>
+서비스는 개인정보 처리에 관한 업무를 총괄하여 책임지고,
+개인정보 처리와 관련한 이용자의 불만 및 피해 구제를 처리하기 위하여
+아래와 같이 개인정보 보호책임자를 지정하고 있습니다.
+</p>
+<table>
+  <tbody>
+    <tr><th>개인정보 보호책임자</th><td>플랜메이트 운영팀</td></tr>
+    <tr><th>이메일</th><td><a href="mailto:arlawjdqls@mju.ac.kr">arlawjdqls@mju.ac.kr</a></td></tr>
+  </tbody>
+</table>
+<p>
+개인정보 침해에 대한 신고나 상담이 필요한 경우 아래 기관에 문의할 수 있습니다.
+</p>
+<ul>
+  <li>개인정보침해 신고센터 — <a href="https://privacy.kisa.or.kr" target="_blank" rel="noopener">privacy.kisa.or.kr</a> / 국번없이 118</li>
+  <li>개인정보 분쟁조정위원회 — <a href="https://www.kopico.go.kr" target="_blank" rel="noopener">www.kopico.go.kr</a> / 1833-6972</li>
+  <li>대검찰청 사이버수사과 — 국번없이 1301</li>
+  <li>경찰청 사이버수사국 — 국번없이 182</li>
+</ul>
+
+<h2>12. 개인정보처리방침의 변경</h2>
+<p>
+본 개인정보처리방침의 내용이 추가·삭제·수정되는 경우,
+변경 사항의 시행 7일 전부터 서비스 내 공지사항을 통해 안내합니다.
+다만 이용자의 권리에 중대한 변경이 발생하는 경우에는 최소 30일 전에 공지합니다.
+</p>
+
+<footer>
+  공고일: 2026년 7월 11일 · 시행일: 2026년 7월 18일
+</footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 개요

앱 스토어 등록에 필요한 개인정보처리방침 페이지를 추가합니다.

- 파일: `public/privacy-policy.html`
- 접근 경로: `/privacy-policy.html`
- `public/` 하위 정적 파일이라 빌드 시 그대로 복사되며, 기존 네이버 인증 html과 동일하게 vercel rewrite보다 우선 적용됩니다.

## 작성 근거

Backend-v2 코드 기준으로 실제 수집 항목을 반영했습니다.

- `User` 엔티티 — 이메일, 비밀번호, 닉네임, 생년월일, 성별, FCM 토큰, provider/providerId
- OAuth — 구글, 네이버, 카카오
- 외부 연동 — Firebase(FCM), Gemini API(일정 추천), ODsay(대중교통), OpenStreetMap(도보 경로)
- 일정 / 목적지 / 시간표 / 동행요청 / 베타피드백 도메인

## 머지 전 확인이 필요한 부분

- [ ] **탈퇴 후 30일 파기** — 현재 `BaseSoftDeleteEntity` 기반 soft delete만 있고 하드 삭제 스케줄러가 없습니다. 방침대로 동작시키려면 배치가 필요하거나, 문구를 실제 동작에 맞게 수정해야 합니다.
- [ ] **회원 탈퇴 경로** — "마이페이지 > 탈퇴하기"로 기재했습니다. 실제 메뉴명 확인 필요.
- [ ] **보호책임자 연락처** — 개인 메일로 되어 있습니다. 팀 공용 메일이 있으면 교체 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)